### PR TITLE
Add new "tweak" to disable dyer bleaching wools to obtain white

### DIFF
--- a/src/main/java/steve_gall/minecolonies_tweaks/core/common/config/JobConfig.java
+++ b/src/main/java/steve_gall/minecolonies_tweaks/core/common/config/JobConfig.java
@@ -24,6 +24,7 @@ public class JobConfig
 	public final IntValue craftingHittingTime;
 	public final IntValue craftingDecideDelay;
 	public final IntValue sifterProgressMultiplier;
+	public final BooleanValue dyerDisableBleaching;
 	public final IntValue farmerWorkDelay;
 	public final DoubleValue farmerSkillDivider;
 	public final IntValue farmerActionsDoneUntilDumping;
@@ -56,6 +57,11 @@ public class JobConfig
 		builder.push("sifter");
 		builder.comment("siftingTicks = progressMultiplier - strengthLevel");
 		this.sifterProgressMultiplier = builder.defineInRange("progressMultiplier", EntityAIWorkSifterAccessor.getMaxLevel(), 0, Integer.MAX_VALUE);
+		builder.pop();
+
+		builder.push("dyer");
+		builder.comment("disables wool bleaching to avoid wool loop crafting. To take effect it requires using the command \"/mc colony requestsystem-reset-all\"");
+		this.dyerDisableBleaching = builder.define("dyerDisableBleaching", true);
 		builder.pop();
 
 		builder.push("farmer");

--- a/src/main/java/steve_gall/minecolonies_tweaks/mixin/common/minecolonies/BuildingDyerCraftingModuleMixin.java
+++ b/src/main/java/steve_gall/minecolonies_tweaks/mixin/common/minecolonies/BuildingDyerCraftingModuleMixin.java
@@ -1,0 +1,22 @@
+package steve_gall.minecolonies_tweaks.mixin.common.minecolonies;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.core.colony.buildings.workerbuildings.BuildingDyer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import steve_gall.minecolonies_tweaks.core.common.config.MCTweaksConfigServer;
+
+@Mixin(value = BuildingDyer.CraftingModule.class, remap = false)
+public abstract class BuildingDyerCraftingModuleMixin {
+
+    // We have to inject inside the "if" because using the super call as target is not allowed...
+    @Inject(method = "getFirstRecipe", remap = false, at = @At(value = "INVOKE", target = "Ljava/util/function/Predicate;test(Ljava/lang/Object;)Z", remap = false), cancellable = true)
+    void getFirstRecipeIgnoreBleach(CallbackInfoReturnable<IRecipeStorage> cir, @Local IRecipeStorage recipe) {
+        if (MCTweaksConfigServer.INSTANCE.jobs.dyerDisableBleaching.get()) {
+            cir.setReturnValue(recipe);
+        }
+    }
+}

--- a/src/main/resources/minecolonies_tweaks.mixin.common.json
+++ b/src/main/resources/minecolonies_tweaks.mixin.common.json
@@ -13,6 +13,7 @@
 		"minecolonies.AbstractEntityAIStructureAccessor",
 		"minecolonies.AbstractEntityAIStructureMixin",
 		"minecolonies.AbstractEntityMinecoloniesRaiderMixin",
+		"minecolonies.BuildingDyerCraftingModuleMixin",
 		"minecolonies.BuildingExtensionsModuleMixin",
 		"minecolonies.BuildingStructureHandlerMixin",
 		"minecolonies.CitizenMournHandlerMixin",


### PR DESCRIPTION
This "fixes" this:

<img width="324" height="348" alt="Captura de pantalla 2025-07-16 081524" src="https://github.com/user-attachments/assets/2e9d3497-8165-4f8c-9348-b34d4b0f973e" />

It is a hardcoded recipe that the Dyer has to bleach any colored Wool into White Wool, and it can't be disabled. I've found this "feature" super annoying and seen multiple complaints in the official Discord and Github that date back to 2020...

With this feature disabled, the White Wool remains as White Wool in the requests, so it doesn't consume other Wool coloes to obtain it, and it you have other mods installed that try to satisfy those requests from another storage system (like CC and RS for example), this will correctly pull White Wool when needed.

It requires colling the command "/mc colony requestsystem-reset-all" after disablign the recipe so the request system recalculates all the neccessary materials and recipes, but it works.